### PR TITLE
Add infinite scroll for related posts

### DIFF
--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -9,6 +9,10 @@ body {
 	color: black;
 }
 
+amp-next-page {
+	grid-column: span 12;
+}
+
 .header, .main, .footer {
 	grid-column: 4 / span 6;
 }
@@ -151,6 +155,7 @@ body {
 	display: flex;
 	justify-content: space-between;
 	flex-wrap: wrap;
+	margin-bottom: 1em;
 }
 
 h1 {

--- a/assets/theme.scss
+++ b/assets/theme.scss
@@ -448,6 +448,7 @@ blockquote {
 	.footer {
 		flex-direction: column;
 		align-items: center;
+		margin-bottom: 1em;
 	}
 	.header {
 		margin: 0;

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,5 +17,8 @@
 		<footer class="footer">
 			{{- partial "footer/base.html" . -}}
 		</footer>
+		{{ if .IsPage }}
+			{{- partial "page/infinite-scroll.html" . -}}
+		{{ end }}
 	</body>
 </html>

--- a/layouts/partials/head/amp-components.html
+++ b/layouts/partials/head/amp-components.html
@@ -24,3 +24,6 @@
         <script async custom-element="amp-auto-ads" src="https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js"></script>
     {{ end }}
 {{ end }}
+{{ if .IsPage }}
+    <script async custom-element="amp-next-page" src="https://cdn.ampproject.org/v0/amp-next-page-1.0.js"></script>
+{{ end }}

--- a/layouts/partials/header/base.html
+++ b/layouts/partials/header/base.html
@@ -1,4 +1,4 @@
-<nav class="header__menu">
+<nav class="header__menu" next-page-hide>
     <a class="header__menu__logo" data-rel="prefetch" href="{{ "" | absLangURL }}" aria-label="{{ i18n "goBackHome" }}">
         {{- partial "header/logo.html" . -}}
     </a>

--- a/layouts/partials/header/search.html
+++ b/layouts/partials/header/search.html
@@ -4,7 +4,8 @@
     filter-value="title"
     src="{{ `search.json` | absLangURL }}"
     min-characters="1"
-    class="header__search">
+    class="header__search"
+    next-page-hide>
     <input class="header__search__input" type="text" placeholder="{{ i18n "search"}}" aria-label="{{ i18n "search"}}">
     <template class="header__search__item-template" type="amp-mustache" id="amp-template-custom">
         <div class="search-item" data-value="{{ `{{url}}` }}">

--- a/layouts/partials/page/infinite-scroll.html
+++ b/layouts/partials/page/infinite-scroll.html
@@ -1,0 +1,18 @@
+{{ $related := .Site.RegularPages.Related . | first 3 }}
+
+{{ with $related }}
+<amp-next-page>
+    <script type="application/json">
+        [
+            {{- range $index, $post := . -}}
+                {{- if ne $index 0 -}},{{- end -}}
+                {
+                    "image": "",
+                    "title": "{{ .Title }}",
+                    "url": "{{ .Permalink }}"
+                }
+            {{- end -}}
+        ]
+    </script>
+</amp-next-page>
+{{ end }}


### PR DESCRIPTION
This feature adds infinite scroll for single pages related content using `amp-next-page` component.